### PR TITLE
Fix typo in name of function SQLEndTran.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -503,7 +503,7 @@ extern "C" {
     ///
     /// # Returns
     /// `SQL_SUCCESS`, `SQL_SUCCESS_WITH_INFO`, `SQL_ERROR`, `SQL_INVALID_HANDLE`, or `SQL_STILL_EXECUTING`.
-    pub fn SQLEndTrans(
+    pub fn SQLEndTran(
         handle_type: HandleType,
         handle: SQLHANDLE,
         completion_type: SqlCompletionType,


### PR DESCRIPTION
Due to running only `cargo check` and not `cargo test` on the previous code, I did miss a typo I made in the name of `SQLEndTran` (without an `s` at the end) in the previous PR. This fixes that mistake so that the code not only compiles but also properly links. Sorry for that... |:-\