### PR TITLE
lib.rs: Fix extern calling convention

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -213,7 +213,7 @@ pub use self::SqlCompletionType::*;
 
 #[cfg_attr(windows, link(name = "odbc32"))]
 #[cfg_attr(not(windows), link(name = "odbc"))]
-extern "C" {
+extern "system" {
     /// Allocates an environment, connection, statement, or descriptor handle.
     ///
     /// # Returns


### PR DESCRIPTION
32-bit Windows uses `__stdcall` instead of `C`, we can use `system` to handle both x86/x64
This fixes linker errors on `stable-i686-pc-windows-msvc`