### PR TITLE
Apply ctest to verify binding correctness + small fix

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,3 +22,7 @@ odbc_version_4 = ["odbc_version_3_80"]
 
 [badges]
 travis-ci = { repository = "pacman82/odbc-sys", branch = "master" }
+
+[workspace]
+members = ["systest"]
+default-members = [".", "systest"]

--- a/src/input_output.rs
+++ b/src/input_output.rs
@@ -1,5 +1,5 @@
 /// Used by `SQLBindParameter`.
-#[repr(u16)]
+#[repr(i16)]
 #[allow(non_camel_case_types)]
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
 pub enum InputOutput {

--- a/systest/Cargo.toml
+++ b/systest/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "systest"
+version = "0.1.0"
+authors = ["Konstantin Salikhov <koka58@yandex.ru>"]
+build = "build.rs"
+
+[dependencies]
+odbc-sys = { path = ".." }
+
+[build-dependencies]
+ctest = "0.1"
+

--- a/systest/build.rs
+++ b/systest/build.rs
@@ -1,0 +1,73 @@
+extern crate ctest;
+
+fn build_ctest() {
+    let mut cfg = ctest::TestGenerator::new();
+
+    // Include the header files where the C APIs are defined
+    cfg.header("odbcinst.h")
+        .header("sql.h")
+        .header("sqlext.h")
+        .header("sqltypes.h")
+        .header("sqlucode.h");
+
+    //TODO: enum values are not checked now - only constants are
+
+    //TODO: those are not really checked - be careful
+    cfg.type_name(|ty, is_struct| if is_struct {
+        match ty.to_string().as_ref() {
+            "HandleType" => "SQLSMALLINT".to_owned(),
+            "SqlStatementAttribute" => "SQLINTEGER".to_owned(),
+            "EnvironmentAttribute" => "SQLINTEGER".to_owned(),
+            "FetchOrientation" => "SQLUSMALLINT".to_owned(),
+            "FreeStmtOption" => "SQLUSMALLINT".to_owned(),
+            "SqlDataType" => "SQLSMALLINT".to_owned(),
+            "SqlCDataType" => "SQLSMALLINT".to_owned(),
+            "InfoType" => "SQLUSMALLINT".to_owned(),
+            "SqlConnectionAttribute" => "SQLINTEGER".to_owned(),
+            "SqlCompletionType" => "SQLSMALLINT".to_owned(),
+            "InputOutput" => "SQLSMALLINT".to_owned(),
+            "SqlDriverConnectOption" => "SQLUSMALLINT".to_owned(),
+            "Nullable" => "SQLSMALLINT".to_owned(),
+            _ => ty.to_string()
+        }
+    } else {
+        ty.to_string()
+    });
+
+    let skip_signedness = vec![
+        "SQLHENV",
+        "SQLHDBC",
+        "SQLHSTMT",
+        "SQLPOINTER",
+        "SQLHWND",
+        "SQLHANDLE",
+    ];
+
+    cfg.skip_signededness(move |t| skip_signedness.contains(&t));
+
+    //TODO: those are incompatible with headers due to difference in constness of raw pointers for input params
+    let skip_fn = vec![
+        "SQLPrepare",
+        "SQLExecDirect",
+        "SQLConnect",
+        "SQLExecDirect",
+        "SQLTables",
+        "SQLDriverConnect"
+    ];
+
+    cfg.skip_fn(move |t| skip_fn.contains(&t));
+
+    // Include the directory where the header files are defined
+    // cfg.include("/usr/local/include/");
+
+    // Generate the tests, passing the path to the `*-sys` library as well as
+    // the module to generate.
+    cfg.generate("../src/lib.rs", "all.rs");
+}
+
+fn main() {
+    if cfg!(not(target_os = "windows")) {
+        build_ctest();
+    }
+
+}

--- a/systest/src/main.rs
+++ b/systest/src/main.rs
@@ -1,0 +1,13 @@
+#![allow(bad_style, unused_macros)]
+
+extern crate odbc_sys;
+use odbc_sys::*;
+
+#[cfg(not(target_os = "windows"))]
+include!(concat!(env!("OUT_DIR"), "/all.rs"));
+
+#[test]
+#[cfg(not(target_os = "windows"))]
+fn test_correctness() {
+    main()
+}


### PR DESCRIPTION
Hi @pacman82, I was playing with [ctest](https://github.com/alexcrichton/ctest) FFI binding test generator and remembered of this crate. We could incorporate `ctest` as another test step in build pipeline to ensure that bindings provided by this crate are matching appropriate C header files.

Unfortunately, `ctest` don't support enums (maybe because of reasons described in https://github.com/pacman82/odbc-sys/issues/12), so it requires some amount of manual configuration to work properly.

There's also a problem of some input parameters declared as `*const SOMETHING` in rust and just `* SOMETHING` in headers - so we need either declare them as `*mut SOMETHING` in rust or declare them as excluded in test generator configuration. For now I've declared those functions as exclusions to avoid changing original function signatures.

Despite of those problems this binding checker still can be useful to avoid mismatches while manually binding functions. For example I've found that `InputOutput` enum is declared as `u16` instead of `i16`.

Anyway it's of course up to you - feel free to simply close this PR if you decide that this binding checker is an unnecessary burden an introduces more problems than it solves.
