### PR TITLE
Add support for static linking

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,10 @@ rust:
 os:
  - linux
  - osx
+env:
+  - FLAGS=
+  - FLAGS=--features static
+
 matrix:
   allow_failures:
    - rust: nightly

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 sudo: false
+dist: bionic
 language: rust
 rust:
  - stable

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,10 @@ env:
   - FLAGS=
   - FLAGS=--features static
 
+script:
+  - cargo build --verbose --all $FLAGS
+  - cargo test --verbose --all $FLAGS
+
 matrix:
   allow_failures:
    - rust: nightly

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ os:
  - osx
 env:
   - FLAGS=
-  - FLAGS="--features static"
+  - FLAGS="--features static" ODBC_SYS_STATIC_PATH=/usr/lib/x86_64-linux-gnu/
 
 script:
   - cargo build --verbose --all $FLAGS

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ os:
  - osx
 env:
   - FLAGS=
-  - FLAGS=--features static
+  - FLAGS="--features static"
 
 script:
   - cargo build --verbose --all $FLAGS

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,7 @@ matrix:
      rust: beta
 before_install: |
   if [ "$TRAVIS_OS_NAME" == "osx" ]; then
+    # FIXME: Workaround for https://travis-ci.community/t/syntax-error-unexpected-keyword-rescue-expecting-keyword-end-in-homebrew/5623/4
     HOMEBREW_NO_AUTO_UPDATE=1 brew install unixodbc
   fi
 addons:

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ matrix:
      rust: beta
 before_install: |
   if [ "$TRAVIS_OS_NAME" == "osx" ]; then
-    brew install unixodbc
+    HOMEBREW_NO_AUTO_UPDATE=1 brew install unixodbc
   fi
 addons:
   apt:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ categories = ["external-ffi-bindings", "database"]
 
 [features]
 default = ["odbc_version_3_80"]
+static = []
 
 odbc_version_3_50 = []
 odbc_version_3_80 = ["odbc_version_3_50"]

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -40,6 +40,10 @@ environment:
   # Stable 64-bit MSVC
     - channel: stable
       target: x86_64-pc-windows-msvc
+  # Stable 64-bit MSVC, static linking
+    - channel: stable
+      target: x86_64-pc-windows-msvc
+      cargoflags: --features "static"
   # # Stable 32-bit MSVC
   #  - channel: stable
   #    target: i686-pc-windows-msvc
@@ -56,6 +60,10 @@ environment:
   # Stable 64-bit GNU
     - channel: stable
       target: x86_64-pc-windows-gnu
+  # Stable 64-bit GNU, static linking
+    - channel: stable
+      target: x86_64-pc-windows-gnu
+      cargoflags: --features "static"
   # # Stable 32-bit GNU
   #  - channel: stable
   #    target: i686-pc-windows-gnu

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -33,6 +33,7 @@ os: Visual Studio 2015
 # channels to enable unstable features when building for nightly. Or you could add additional
 # matrix entries to test different combinations of features.
 environment:
+  ODBC_SYS_STATIC_PATH: C:\Program Files (x86)\Windows Kits\8.1\Lib\winv6.3\um\x64
   matrix:
 
 ### MSVC Toolchains ###

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -33,7 +33,6 @@ os: Visual Studio 2015
 # channels to enable unstable features when building for nightly. Or you could add additional
 # matrix entries to test different combinations of features.
 environment:
-  ODBC_SYS_STATIC_PATH: C:\Program Files (x86)\Windows Kits\8.1\Lib\winv6.3\um\x64
   matrix:
 
 ### MSVC Toolchains ###
@@ -41,10 +40,6 @@ environment:
   # Stable 64-bit MSVC
     - channel: stable
       target: x86_64-pc-windows-msvc
-  # Stable 64-bit MSVC, static linking
-    - channel: stable
-      target: x86_64-pc-windows-msvc
-      cargoflags: --features "static"
   # # Stable 32-bit MSVC
   #  - channel: stable
   #    target: i686-pc-windows-msvc
@@ -61,10 +56,6 @@ environment:
   # Stable 64-bit GNU
     - channel: stable
       target: x86_64-pc-windows-gnu
-  # Stable 64-bit GNU, static linking
-    - channel: stable
-      target: x86_64-pc-windows-gnu
-      cargoflags: --features "static"
   # # Stable 32-bit GNU
   #  - channel: stable
   #    target: i686-pc-windows-gnu

--- a/build.rs
+++ b/build.rs
@@ -1,5 +1,8 @@
 fn main() {
     if cfg!(r#static) {
+        let static_path = std::env::var("ODBC_SYS_STATIC_PATH").unwrap_or("/usr/lib".to_string());
+        println!("cargo:rerun-if-env-changed=ODBC_SYS_STATIC_PATH");
+        println!("cargo:rustc-link-search=native={}", static_path);
         println!("cargo:rustc-link-lib=static=odbc");
     }
 

--- a/build.rs
+++ b/build.rs
@@ -1,5 +1,5 @@
 fn main() {
-    if cfg!(r#static) {
+    if std::env::var("CARGO_FEATURE_STATIC").is_ok() {
         let static_path = std::env::var("ODBC_SYS_STATIC_PATH").unwrap_or("/usr/lib".to_string());
         println!("cargo:rerun-if-env-changed=ODBC_SYS_STATIC_PATH");
         println!("cargo:rustc-link-search=native={}", static_path);

--- a/build.rs
+++ b/build.rs
@@ -1,4 +1,8 @@
 fn main() {
+    if cfg!(r#static) {
+        println!("cargo:rustc-link-lib=static=odbc");
+    }
+
     if cfg!(target_os = "macos") {
         // if we're on Mac OS X we'll kindly add DYLD_LIBRARY_PATH to rustc's
         // linker search path

--- a/build.rs
+++ b/build.rs
@@ -4,6 +4,9 @@ fn main() {
         println!("cargo:rerun-if-env-changed=ODBC_SYS_STATIC_PATH");
         println!("cargo:rustc-link-search=native={}", static_path);
         println!("cargo:rustc-link-lib=static=odbc");
+        if cfg!(not(target_os = "windows")) {
+            println!("cargo:rustc-link-lib=static=ltdl");
+        }
     }
 
     if cfg!(target_os = "macos") {

--- a/build.rs
+++ b/build.rs
@@ -1,12 +1,13 @@
 fn main() {
     if std::env::var("CARGO_FEATURE_STATIC").is_ok() {
+        if cfg!(target_os = "windows") {
+            panic!("odbc-sys does not currently support static linking on windows");
+        }
         let static_path = std::env::var("ODBC_SYS_STATIC_PATH").unwrap_or("/usr/lib".to_string());
         println!("cargo:rerun-if-env-changed=ODBC_SYS_STATIC_PATH");
         println!("cargo:rustc-link-search=native={}", static_path);
         println!("cargo:rustc-link-lib=static=odbc");
-        if cfg!(not(target_os = "windows")) {
-            println!("cargo:rustc-link-lib=static=ltdl");
-        }
+        println!("cargo:rustc-link-lib=static=ltdl");
         if cfg!(target_os = "macos") {
             // Homebrew's unixodbc uses the system iconv, so we can't do a fully static linking
             // but this way we at least have only dependencies on built-in libraries

--- a/build.rs
+++ b/build.rs
@@ -7,6 +7,12 @@ fn main() {
         if cfg!(not(target_os = "windows")) {
             println!("cargo:rustc-link-lib=static=ltdl");
         }
+        if cfg!(target_os = "macos") {
+            // Homebrew's unixodbc uses the system iconv, so we can't do a fully static linking
+            // but this way we at least have only dependencies on built-in libraries
+            // See also https://github.com/Homebrew/homebrew-core/pull/46145
+            println!("cargo:rustc-link-lib=dylib=iconv");
+        }
     }
 
     if cfg!(target_os = "macos") {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -462,8 +462,8 @@ pub enum SqlCompletionType {
 
 pub use self::SqlCompletionType::*;
 
-#[cfg_attr(all(windows, not(r#static)), link(name = "odbc32"))]
-#[cfg_attr(all(windows, r#static), link(name = "odbc32", kind = "static"))]
+// static linking is not currently supported here for windows
+#[cfg_attr(windows, link(name = "odbc32"))]
 #[cfg_attr(all(not(windows), not(r#static)), link(name = "odbc"))]
 #[cfg_attr(all(not(windows), r#static), link(name = "odbc", kind = "static"))]
 extern "system" {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -462,8 +462,10 @@ pub enum SqlCompletionType {
 
 pub use self::SqlCompletionType::*;
 
-#[cfg_attr(windows, link(name = "odbc32"))]
-#[cfg_attr(not(windows), link(name = "odbc"))]
+#[cfg_attr(all(windows, not(r#static)), link(name = "odbc32"))]
+#[cfg_attr(all(windows, r#static), link(name = "odbc32", kind = "static"))]
+#[cfg_attr(all(not(windows), not(r#static)), link(name = "odbc"))]
+#[cfg_attr(all(not(windows), r#static), link(name = "odbc", kind = "static"))]
 extern "system" {
     /// Allocates an environment, connection, statement, or descriptor handle.
     ///


### PR DESCRIPTION
Enable support for static linking with the feature flag `static`. This aids the building of single binaries with no system dependencies on systems that support static linking with Rust (e.g. particularly alpine, but theoretically others).