### PR TITLE
Added missing environment attribute values

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,22 @@
 Changelog
 =========
 
+0.8.3
+-----
+
+* Adds `attributes::SQL_ATTR_CONNECTION_POOLING` and `attributes::SQL_ATTR_CP_MATCH` enums
+* Implements Default trait for attribute values
+
+
+### BREAKING CHANGES
+
+* `SQL_ATTR_APPLICATION_KEY` constant removed because it is not part of the ODBC standard.
+If there is any software that depends on this constant defined, users are encouraged to open an
+issue report
+* `SQL_OV_ODBC_2` constant removed because odbc-sys does not support OBDC versions < 3.0.
+* Enum OdbcVersion renamed to `SQL_ATTR_ODBC_VERSION` to better reflect it's intended use as a value
+for environment attribute to be used with `SQLSetEnvAttr` and `SQLGetEnvAttr` functions
+
 0.8.2
 -----
 

--- a/src/attributes.rs
+++ b/src/attributes.rs
@@ -1,4 +1,4 @@
-use std::os::raw::c_void;
+use crate::SQLPOINTER;
 
 /// Governs behaviour of EnvironmentAttribute
 #[repr(i32)]
@@ -8,16 +8,19 @@ pub enum EnvironmentAttribute {
     SQL_ATTR_ODBC_VERSION = 200,
     SQL_ATTR_CONNECTION_POOLING = 201,
     SQL_ATTR_CP_MATCH = 202,
+    // This attribute was commented out because there is no mention of it in the ODBC
+    // specification nor does this attribute exist in unixODBC or iODBC implementations.
+    // This attribute exists in Microsoft implementation only and it's usage is unclear.
     // For private driver manager
-    SQL_ATTR_APPLICATION_KEY = 203,
+    //SQL_ATTR_APPLICATION_KEY = 203,
     SQL_ATTR_OUTPUT_NTS = 10001,
 }
 pub use EnvironmentAttribute::*;
 
 /// ODBC verions
 ///
-/// Used in conjunction with `SQL_ATTR_ODBC_VERSION` and `SQLSetEnvAttr` to declare the ODBC
-/// version used by the application.
+/// Possible values for `SQL_ATTR_ODBC_VERSION` attribute set with `SQLSetEnvAttr` to
+/// declare ODBC version
 #[allow(non_camel_case_types)]
 #[repr(i32)]
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
@@ -31,8 +34,73 @@ pub enum OdbcVersion {
 }
 pub use OdbcVersion::*;
 
-impl From<OdbcVersion> for *mut c_void {
-    fn from(source: OdbcVersion) -> *mut c_void {
-        source as i32 as *mut c_void
+impl From<OdbcVersion> for SQLPOINTER {
+    fn from(source: OdbcVersion) -> SQLPOINTER {
+        source as i32 as SQLPOINTER
+    }
+}
+
+/// Connection pool configuration
+///
+/// Possible values for `SQL_ATTR_CONNECTION_POOLING` attribute set with `SQLSetEnvAttr` to define
+/// which pooling scheme will be used
+#[allow(non_camel_case_types)]
+#[repr(u32)]
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+pub enum ConnPoolConfig {
+    SQL_CP_OFF = 0,
+    SQL_CP_ONE_PER_DRIVER = 1,
+    SQL_CP_ONE_PER_HENV = 2,
+    SQL_CP_DRIVER_AWARE = 3,
+}
+pub use ConnPoolConfig::*;
+
+/// Connection pool default configuration
+pub const SQL_CP_DEFAULT: ConnPoolConfig = ConnPoolConfig::SQL_CP_OFF;
+
+impl From<ConnPoolConfig> for SQLPOINTER {
+    fn from(source: ConnPoolConfig) -> SQLPOINTER {
+        source as u32 as SQLPOINTER
+    }
+}
+
+/// Matching of pooled connections
+///
+/// Possible values for `SQL_ATTR_CP_MATCH` attribute set with `SQLSetEnvAttr` to define
+/// which connection attributes must match for a connection returned from the pool
+#[allow(non_camel_case_types)]
+#[repr(u32)]
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+pub enum ConnPoolMatch {
+    SQL_CP_STRICT_MATCH = 0,
+    SQL_CP_RELAXED_MATCH = 1,
+}
+pub use ConnPoolMatch::*;
+
+/// Default matching for connections returned from the pool
+pub const SQL_CP_MATCH_DEFAULT: ConnPoolMatch = ConnPoolMatch::SQL_CP_STRICT_MATCH;
+
+impl From<ConnPoolMatch> for SQLPOINTER {
+    fn from(source: ConnPoolMatch) -> SQLPOINTER {
+        source as u32 as SQLPOINTER
+    }
+}
+
+/// Enable/disable null-terminated strings
+///
+/// Possible values for `SQL_ATTR_OUTPUT_NTS` attribute set with `SQLSetEnvAttr` to
+/// enable/disable null-terminated strings
+#[allow(non_camel_case_types)]
+#[repr(i32)]
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+pub enum OutputNTS {
+    SQL_FALSE = 0,
+    SQL_TRUE = 1,
+}
+pub use OutputNTS::*;
+
+impl From<OutputNTS> for SQLPOINTER {
+    fn from(source: OutputNTS) -> SQLPOINTER {
+        source as i32 as SQLPOINTER
     }
 }

--- a/src/attributes.rs
+++ b/src/attributes.rs
@@ -1,5 +1,10 @@
 use crate::SQLPOINTER;
 
+pub use EnvironmentAttribute::*;
+pub use SQL_ATTR_CONNECTION_POOLING::*;
+pub use SQL_ATTR_CP_MATCH::*;
+pub use SQL_ATTR_ODBC_VERSION::*;
+
 /// Governs behaviour of EnvironmentAttribute
 #[repr(i32)]
 #[allow(non_camel_case_types)]
@@ -15,37 +20,35 @@ pub enum EnvironmentAttribute {
     //SQL_ATTR_APPLICATION_KEY = 203,
     SQL_ATTR_OUTPUT_NTS = 10001,
 }
-pub use EnvironmentAttribute::*;
 
 /// ODBC verions
 ///
 /// Possible values for `SQL_ATTR_ODBC_VERSION` attribute set with `SQLSetEnvAttr` to
 /// declare ODBC version
-#[allow(non_camel_case_types)]
 #[repr(i32)]
+#[allow(non_camel_case_types)]
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
 pub enum SQL_ATTR_ODBC_VERSION {
-    SQL_OV_ODBC2 = 2,
+    // Not supported by this crate
+    // SQL_OV_ODBC2 = 2,
     SQL_OV_ODBC3 = 3,
     #[cfg(feature = "odbc_version_3_80")]
     SQL_OV_ODBC3_80 = 380,
     #[cfg(feature = "odbc_version_4")]
     SQL_OV_ODBC4 = 400,
 }
-pub use SQL_ATTR_ODBC_VERSION::*;
 
 impl From<SQL_ATTR_ODBC_VERSION> for SQLPOINTER {
     fn from(source: SQL_ATTR_ODBC_VERSION) -> SQLPOINTER {
         source as i32 as SQLPOINTER
     }
 }
-
 /// Connection pool configuration
 ///
 /// Possible values for `SQL_ATTR_CONNECTION_POOLING` attribute set with `SQLSetEnvAttr` to define
 /// which pooling scheme will be used
-#[allow(non_camel_case_types)]
 #[repr(u32)]
+#[allow(non_camel_case_types)]
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
 pub enum SQL_ATTR_CONNECTION_POOLING {
     SQL_CP_OFF = 0,
@@ -53,10 +56,15 @@ pub enum SQL_ATTR_CONNECTION_POOLING {
     SQL_CP_ONE_PER_HENV = 2,
     SQL_CP_DRIVER_AWARE = 3,
 }
-pub use SQL_ATTR_CONNECTION_POOLING::*;
 
 /// Connection pool default configuration
 pub const SQL_CP_DEFAULT: SQL_ATTR_CONNECTION_POOLING = SQL_ATTR_CONNECTION_POOLING::SQL_CP_OFF;
+
+impl Default for SQL_ATTR_CONNECTION_POOLING {
+    fn default() -> Self {
+        SQL_CP_DEFAULT
+    }
+}
 
 impl From<SQL_ATTR_CONNECTION_POOLING> for SQLPOINTER {
     fn from(source: SQL_ATTR_CONNECTION_POOLING) -> SQLPOINTER {
@@ -68,17 +76,22 @@ impl From<SQL_ATTR_CONNECTION_POOLING> for SQLPOINTER {
 ///
 /// Possible values for `SQL_ATTR_CP_MATCH` attribute set with `SQLSetEnvAttr` to define
 /// which connection attributes must match for a connection returned from the pool
-#[allow(non_camel_case_types)]
 #[repr(u32)]
+#[allow(non_camel_case_types)]
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
 pub enum SQL_ATTR_CP_MATCH {
     SQL_CP_STRICT_MATCH = 0,
     SQL_CP_RELAXED_MATCH = 1,
 }
-pub use SQL_ATTR_CP_MATCH::*;
 
 /// Default matching for connections returned from the pool
 pub const SQL_CP_MATCH_DEFAULT: SQL_ATTR_CP_MATCH = SQL_ATTR_CP_MATCH::SQL_CP_STRICT_MATCH;
+
+impl Default for SQL_ATTR_CP_MATCH {
+    fn default() -> Self {
+        SQL_CP_MATCH_DEFAULT
+    }
+}
 
 impl From<SQL_ATTR_CP_MATCH> for SQLPOINTER {
     fn from(source: SQL_ATTR_CP_MATCH) -> SQLPOINTER {

--- a/src/attributes.rs
+++ b/src/attributes.rs
@@ -24,7 +24,7 @@ pub use EnvironmentAttribute::*;
 #[allow(non_camel_case_types)]
 #[repr(i32)]
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
-pub enum OdbcVersion {
+pub enum SQL_ATTR_ODBC_VERSION {
     SQL_OV_ODBC2 = 2,
     SQL_OV_ODBC3 = 3,
     #[cfg(feature = "odbc_version_3_80")]
@@ -32,10 +32,10 @@ pub enum OdbcVersion {
     #[cfg(feature = "odbc_version_4")]
     SQL_OV_ODBC4 = 400,
 }
-pub use OdbcVersion::*;
+pub use SQL_ATTR_ODBC_VERSION::*;
 
-impl From<OdbcVersion> for SQLPOINTER {
-    fn from(source: OdbcVersion) -> SQLPOINTER {
+impl From<SQL_ATTR_ODBC_VERSION> for SQLPOINTER {
+    fn from(source: SQL_ATTR_ODBC_VERSION) -> SQLPOINTER {
         source as i32 as SQLPOINTER
     }
 }
@@ -47,19 +47,19 @@ impl From<OdbcVersion> for SQLPOINTER {
 #[allow(non_camel_case_types)]
 #[repr(u32)]
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
-pub enum ConnPoolConfig {
+pub enum SQL_ATTR_CONNECTION_POOLING {
     SQL_CP_OFF = 0,
     SQL_CP_ONE_PER_DRIVER = 1,
     SQL_CP_ONE_PER_HENV = 2,
     SQL_CP_DRIVER_AWARE = 3,
 }
-pub use ConnPoolConfig::*;
+pub use SQL_ATTR_CONNECTION_POOLING::*;
 
 /// Connection pool default configuration
-pub const SQL_CP_DEFAULT: ConnPoolConfig = ConnPoolConfig::SQL_CP_OFF;
+pub const SQL_CP_DEFAULT: SQL_ATTR_CONNECTION_POOLING = SQL_ATTR_CONNECTION_POOLING::SQL_CP_OFF;
 
-impl From<ConnPoolConfig> for SQLPOINTER {
-    fn from(source: ConnPoolConfig) -> SQLPOINTER {
+impl From<SQL_ATTR_CONNECTION_POOLING> for SQLPOINTER {
+    fn from(source: SQL_ATTR_CONNECTION_POOLING) -> SQLPOINTER {
         source as u32 as SQLPOINTER
     }
 }
@@ -71,36 +71,17 @@ impl From<ConnPoolConfig> for SQLPOINTER {
 #[allow(non_camel_case_types)]
 #[repr(u32)]
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
-pub enum ConnPoolMatch {
+pub enum SQL_ATTR_CP_MATCH {
     SQL_CP_STRICT_MATCH = 0,
     SQL_CP_RELAXED_MATCH = 1,
 }
-pub use ConnPoolMatch::*;
+pub use SQL_ATTR_CP_MATCH::*;
 
 /// Default matching for connections returned from the pool
-pub const SQL_CP_MATCH_DEFAULT: ConnPoolMatch = ConnPoolMatch::SQL_CP_STRICT_MATCH;
+pub const SQL_CP_MATCH_DEFAULT: SQL_ATTR_CP_MATCH = SQL_ATTR_CP_MATCH::SQL_CP_STRICT_MATCH;
 
-impl From<ConnPoolMatch> for SQLPOINTER {
-    fn from(source: ConnPoolMatch) -> SQLPOINTER {
+impl From<SQL_ATTR_CP_MATCH> for SQLPOINTER {
+    fn from(source: SQL_ATTR_CP_MATCH) -> SQLPOINTER {
         source as u32 as SQLPOINTER
-    }
-}
-
-/// Enable/disable null-terminated strings
-///
-/// Possible values for `SQL_ATTR_OUTPUT_NTS` attribute set with `SQLSetEnvAttr` to
-/// enable/disable null-terminated strings
-#[allow(non_camel_case_types)]
-#[repr(i32)]
-#[derive(Debug, PartialEq, Eq, Clone, Copy)]
-pub enum OutputNTS {
-    SQL_FALSE = 0,
-    SQL_TRUE = 1,
-}
-pub use OutputNTS::*;
-
-impl From<OutputNTS> for SQLPOINTER {
-    fn from(source: OutputNTS) -> SQLPOINTER {
-        source as i32 as SQLPOINTER
     }
 }


### PR DESCRIPTION
I've taken the liberty to add missing enumerations for environment attribute values as defined in [microsoft reference](https://docs.microsoft.com/en-us/sql/odbc/reference/syntax/sqlsetenvattr-function?view=sql-server-ver15) and [this document](https://www.simba.com/wp-content/uploads/2016/03/ODBC_specification.pdf). I've also looked into different driver manager implementations.

Even though `SQL_CP_DRIVER_AWARE` is defined by the ODBC specification neither `unixODBC` nor `iODBC` implement it, however Microsoft implementation defines it.

I have defined `SQL_CP_DEFAULT` and `SQL_CP_MATCH_DEFAULT` because `unixODBC`, `iODBC` and Microsoft implementation all define it even though those constants are not defined in the ODBC specification.

I have commented out `SQL_ATTR_APPLICATION_KEY` because I have found no mention of it anywhere except [here](https://github.com/microsoft/ODBC-Specification/blob/master/Windows/inc/sqlext.h). I didn't think it was a good idea to expose as an API unknown fields unsupported by the spec. It can always be enabled if it is discovered that someone depends on this functionality

If naming of `ValuePtr` enums is not pleasing, maybe we can define some other naming scheme. I strongly favor this naming scheme because users, when searching for constants to use as `ValuePtr`value can find them by searching for references of attribute name.