### PR TITLE
Two typos and a broken badge fixed in README, OS-X -> macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Docs](https://docs.rs/odbc-sys/badge.svg)](https://docs.rs/odbc-sys/)
 [![MIT licensed](https://img.shields.io/github/license/mashape/apistatus.svg)](https://github.com/pacman82/odbc-sys/blob/main/LICENSE)
-[![Published](http://meritbadge.herokuapp.com/odbc-sys)](https://crates.io/crates/odbc-sys)
+[![Crates.io version](https://img.shields.io/crates/v/odbc-sys)](https://crates.io/crates/odbc-sys)
 
 FFI (Foreign Function Interface) bindings for ODBC (Open Database Connectivity)
 As ffi bindings to C-APIs are low level by nature this library is intended to be the foundation of
@@ -13,13 +13,13 @@ other libraries to build on top, rather than to be used directly.
 * Providing declarations of ODBC Symbols compatible to the C-Interface of an ODBC Driver Manager
 * Provide correct definition of symbols for Unix and Windows in either 32Bit or 64Bit flavour
 * Not to abstract away any power of the underlying API
-* Increase type safety where feasable
+* Increase type safety where feasible
 * As it is as of now unlikely to happen that anyone is writing ODBC 2.0 applications in Rust
   therefore deprecated symbols like 'SQLAllocEnv' have been left out intentionally.
 
 ## Linking
 
-This library will link against `odbc32.dll` (preinstalled) on Windows systems. On Linux and OS-X it links against `libodbc.so` by default. This is typically provided by [unix-odbc](http://www.unixodbc.org/). Using the `--feature iodbc` you can also link against `libiodbc.so`. This may be interessting if you are trying to connect to some older data sources on OS-X.
+This library will link against `odbc32.dll` (preinstalled) on Windows systems. On Linux and macOS it links against `libodbc.so` by default. This is typically provided by [unix-odbc](http://www.unixodbc.org/). Using the `--feature iodbc` you can also link against `libiodbc.so`. This may be interesting if you are trying to connect to some older data sources on macOS.
 
 ## Installing `unix-odbc`
 
@@ -31,7 +31,7 @@ Use your systems packet manager to install `unixodbc-dev`. E.g. on Ubuntu / Debi
 sudo apt install unixodbc-dev
 ```
 
-### OS-X
+### macOS
 
 On Intel based architectures you can install `unix-odbc` using homebrew.
 
@@ -39,7 +39,7 @@ On Intel based architectures you can install `unix-odbc` using homebrew.
 brew install unixodbc
 ```
 
-Note for **ARM** based OS-X Systems (MAC M1):
+Note for **ARM** based macOS Systems (M1 processors and later):
 
 `cargo build` is not going to pick up `libodbc.so` installed via homebrew due to the fact that homebrew on ARM Mac installs into `/opt/homebrew/Cellar` as opposed to `/usr/local/opt/`.
 
@@ -70,7 +70,7 @@ Thanks to the folks of [docs.rs] for building and hosting the [documentation]!
 
 ## Contributing
 
-Want to help out? Just create an issue, pull request.
+Want to help out? Just create an issue or pull request.
 
 [docs.rs]: https://docs.rs
 [documentation]: https://docs.rs/odbc-sys/


### PR DESCRIPTION
The current badge is broken because it uses HTTP and the whole service seems to be gone

And I renamed OS-X to macOS as it was officially renamed way back in 2016 already so I thought it's about time :)