### PR TITLE
Adds SQLGetPrivateProfileStringW

### DIFF
--- a/src/functions.rs
+++ b/src/functions.rs
@@ -988,7 +988,23 @@ extern "system" {
     pub fn SQLParamData(hstmt: HStmt, value_out: *mut Pointer) -> SqlReturn;
 }
 
-#[link(name = "odbcinst")]
+#[cfg_attr(windows, link(name = "odbc32"))]
+#[cfg_attr(
+    all(not(windows), not(feature = "static"), not(feature = "iodbc")),
+    link(name = "odbcinst")
+)]
+#[cfg_attr(
+    all(not(windows), feature = "static", not(feature = "iodbc")),
+    link(name = "odbcinst", kind = "static")
+)]
+#[cfg_attr(
+    all(not(windows), not(feature = "static"), feature = "iodbc"),
+    link(name = "iodbcinst")
+)]
+#[cfg_attr(
+    all(not(windows), feature = "static", feature = "iodbc"),
+    link(name = "iodbcinst", kind = "static")
+)]
 extern "C" {
     ///  Gets a list of names of values or data corresponding to a value of the system information.
     ///

--- a/src/functions.rs
+++ b/src/functions.rs
@@ -987,3 +987,20 @@ extern "system" {
     /// `INVALID_HANDLE`, or `PARAM_DATA_AVAILABLE`.
     pub fn SQLParamData(hstmt: HStmt, value_out: *mut Pointer) -> SqlReturn;
 }
+
+#[link(name = "odbcinst")]
+extern "C" {
+    ///  Gets a list of names of values or data corresponding to a value of the system information.
+    ///
+    /// # Returns
+    ///
+    /// The amount of characters returned (negative indicates an error)
+    pub fn SQLGetPrivateProfileStringW(
+        section: *const WChar,
+        entry: *const WChar,
+        default: *const WChar,
+        ret_buffer: *mut WChar,
+        ret_buffer_size: i32,
+        filename: *const WChar,
+    ) -> i32;
+}


### PR DESCRIPTION
This is almost certainly not ready to merge.
I only use Linux and only unixODBC, I'm not sure which attributes are needed for Windows or Mac.
I'd appreciate help and I'd also be fine with only making this available on Linux using unixODBC for now and we can extend it later.

This method is needed for drivers because this is used by Drivers to get information about the DSNs from the registry in Windows or the odbc.ini file etc.