### PR TITLE
Update GitHub actions to new versions and maintained alternatives

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # tag=v4.1.1
       - name: Publish to crates.io
         env:
           CARGO_TOKEN: ${{ secrets.CRATES_IO_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # tag=v4.1.1
       - name: Build
         run: cargo build --verbose
       - name: Run tests
@@ -26,7 +26,7 @@ jobs:
     runs-on: windows-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # tag=v4.1.1
       - name: Build
         run: cargo build --verbose
       - name: Run tests
@@ -38,15 +38,12 @@ jobs:
     runs-on: windows-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # tag=v4.1.1
 
       - name: Install 32Bit toolchain
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: stable
           target: i686-pc-windows-msvc
-          default: true
-          override: true
 
       - name: Build
         run: cargo build --verbose
@@ -60,7 +57,7 @@ jobs:
     runs-on: macos-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # tag=v4.1.1
       - name: Build
         run: cargo build --verbose
       - name: Run tests


### PR DESCRIPTION
The current workflow relies on old versions that causes warnings in the build.

The whitespace changes seem to be line endings changed from Windows to Unix standard.
That was unintentional but matches the rest of the project, if you prefer to keep the other line endings I'll change it.