### PR TITLE
Adds a way to maybe convert primitives to strongly typed enums

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ categories = ["external-ffi-bindings", "database"]
 edition = "2021"
 
 [dependencies]
+num_enum = "0.7.1"
 
 [features]
 default = ["odbc_version_3_80"]
@@ -20,4 +21,3 @@ iodbc = []
 odbc_version_3_50 = []
 odbc_version_3_80 = ["odbc_version_3_50"]
 odbc_version_4 = ["odbc_version_3_80"]
-

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,12 @@
 Changelog
 =========
 
+UNRELEASED
+----------
+
+* Adds `HandleType::try_from(i16)` and `EnvironmentAttribute::try_from(i16)`.
+  This adds the first external dependency to this crate: `num_enum` 
+
 0.24.0
 ------
 

--- a/src/attributes.rs
+++ b/src/attributes.rs
@@ -1,8 +1,9 @@
 use crate::Pointer;
+use num_enum::TryFromPrimitive;
 
 /// Governs behaviour of EnvironmentAttribute
 #[repr(i32)]
-#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+#[derive(Debug, PartialEq, Eq, Clone, Copy, TryFromPrimitive)]
 pub enum EnvironmentAttribute {
     OdbcVersion = 200,
     ConnectionPooling = 201,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,9 +10,10 @@
 
 pub use self::{
     attributes::*, bulk_operation::*, c_data_type::*, desc::*, fetch_orientation::*, functions::*,
-    indicator::*, info_type::*, interval::*, nullability::*, param_type::*, sql_data_type::*,
-    sqlreturn::*, set_pos::*,
+    indicator::*, info_type::*, interval::*, nullability::*, param_type::*, set_pos::*,
+    sql_data_type::*, sqlreturn::*,
 };
+use num_enum::TryFromPrimitive;
 use std::os::raw::{c_int, c_void};
 
 mod attributes;
@@ -107,7 +108,7 @@ pub enum FreeStmtOption {
 
 /// Represented in C headers as SQLSMALLINT
 #[repr(i16)]
-#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+#[derive(Debug, PartialEq, Eq, Clone, Copy, TryFromPrimitive)]
 pub enum HandleType {
     Env = 1,
     Dbc = 2,
@@ -116,7 +117,7 @@ pub enum HandleType {
     // Only used between Drivers and Driver Manager to enable connection pooling.
     // https://learn.microsoft.com/en-us/sql/odbc/reference/develop-driver/developing-connection-pool-awareness-in-an-odbc-driver?view=sql-server-ver16
     // Defined in sqlspi.h
-    DbcInfoToken = 6
+    DbcInfoToken = 6,
 }
 
 /// Options for `SQLDriverConnect`


### PR DESCRIPTION
This is a minor change in terms of lines changed but a major change because it introduces the first external dependency.

If you don't like that, we can either
- Leave it out
- Add it behind a feature
- Reimplement the necessary functionality ourselves